### PR TITLE
[Metagenomics Illumina] fix to single-end problem when running with new setup

### DIFF
--- a/Metagenomics/Illumina/Workflow_Documentation/SW_MGIllumina/workflow_code/Snakefile
+++ b/Metagenomics/Illumina/Workflow_Documentation/SW_MGIllumina/workflow_code/Snakefile
@@ -905,7 +905,7 @@ else:
             humann_config --update database_folders nucleotide {params.humann_nucleotide_db_path} > /dev/null 2>&1
             humann_config --update database_folders protein {params.humann_protein_db_path} > /dev/null 2>&1
 
-            humann --input {input.R1} --output {params.output_dir} --threads {resources.cpus} --output-basename {wildcards.ID} --metaphlan-options "--bowtie2db {params.metaphlan_dir} --unclassified_estimation --add_viruses --sample_id {wildcards.ID}" --bowtie-options "--sensitive --mm" > {log} 2>&1
+            humann --input {input.R1} --output {params.output_dir} --threads {resources.cpus} --output-basename {wildcards.ID} --metaphlan-options "--index mpa_vJan21_CHOCOPhlAnSGB_202103 --bowtie2db {params.metaphlan_dir} --unclassified_estimation --add_viruses --sample_id {wildcards.ID}" --bowtie-options "--sensitive --mm" > {log} 2>&1
             mv {params.tmp_metaphlan} {output[3]}
             rm -rf {params.tmp_dir}
             """


### PR DESCRIPTION
**Draft currently until i get confirmation this fixed it from the individual who hit the issue.**

- fix to single-end humann3 run where the ref db for metaphlan needs to be explicitly specified
  - this wasn't always necessary, but it became so a little while back. A fix was already implemented for paired-end, but apparently i didn't catch it for single-end (and it wouldn't cause a problem unless it was the first time a workflow was run on a new system)
  - I have this marked as a draft to be left alone until i get confirmation from Ankur Naqib (works with Stefan Green at Rush) that this solved the issue for him
    - once that's confirmed, i'll update here