### PR TITLE
DGE group stats calculation bug fix

### DIFF
--- a/RNAseq/Pipeline_GL-DPPD-7101_Versions/GL-DPPD-7101-G.md
+++ b/RNAseq/Pipeline_GL-DPPD-7101_Versions/GL-DPPD-7101-G.md
@@ -1391,9 +1391,18 @@ dds <- DESeqDataSetFromTximport(
 )
 
 ### Collapse technical replicates if present ###
-if (any(grepl("_techrep\\d+$", rownames(sampleTable)))) {
-    tech_rep_groups <- sub("_techrep\\d+$", "", rownames(sampleTable))
-    dds <- collapseReplicates(dds, tech_rep_groups)
+tech_rep_pattern <- "_techrep\\d+$"
+if (any(grepl(tech_rep_pattern, rownames(sampleTable)))) {
+    tech_rep_groups <- sub(tech_rep_pattern, "", rownames(sampleTable))
+
+    if (length(unique(tech_rep_groups)) < length(tech_rep_groups)) {
+        # Collapse only if >1 replicate per group exists
+        dds <- collapseReplicates(dds, groupby = tech_rep_groups)
+
+        collapsed_names <- tech_rep_groups[!duplicated(tech_rep_groups)]
+        sampleTable <- sampleTable[match(collapsed_names, tech_rep_groups), , drop = FALSE]
+        rownames(sampleTable) <- collapsed_names
+    }
 }
 
 ### Filter low count genes ###
@@ -1480,7 +1489,7 @@ output_table$LRT.p.value <- res_lrt@listData$padj
 
 ### Add group-wise statistics ###
 tcounts <- as.data.frame(t(normCounts))
-tcounts$group <- sampleTable$condition[match(rownames(tcounts), rownames(sampleTable))]
+tcounts$group <- colData(dds)$condition[match(rownames(tcounts), rownames(colData(dds)))]
 
 ### Aggregate group means and standard deviations ###
 agg_means <- aggregate(. ~ group, data = tcounts, FUN = mean, na.rm = TRUE)

--- a/RNAseq/Workflow_Documentation/NF_RCP/workflow_code/bin/dge_deseq2.Rmd
+++ b/RNAseq/Workflow_Documentation/NF_RCP/workflow_code/bin/dge_deseq2.Rmd
@@ -284,9 +284,18 @@ if (params$microbes) {
     )
 }
 # Collapse technical replicates if present
-if (any(grepl("_techrep\\d+$", rownames(sampleTable)))) {
-    tech_rep_groups <- sub("_techrep\\d+$", "", rownames(sampleTable))
-    dds <- collapseReplicates(dds, tech_rep_groups)
+tech_rep_pattern <- "_techrep\\d+$"
+if (any(grepl(tech_rep_pattern, rownames(sampleTable)))) {
+    tech_rep_groups <- sub(tech_rep_pattern, "", rownames(sampleTable))
+
+    if (length(unique(tech_rep_groups)) < length(tech_rep_groups)) {
+        # Collapse only if >1 replicate per group exists
+        dds <- collapseReplicates(dds, groupby = tech_rep_groups)
+
+        collapsed_names <- tech_rep_groups[!duplicated(tech_rep_groups)]
+        sampleTable <- sampleTable[match(collapsed_names, tech_rep_groups), , drop = FALSE]
+        rownames(sampleTable) <- collapsed_names
+    }
 }
 summary(dds)
 ```
@@ -384,8 +393,8 @@ output_table$All.stdev <- matrixStats::rowSds(as.matrix(normCounts), na.rm = TRU
 output_table$LRT.p.value <- res_lrt@listData$padj
 # Calculate group means and standard deviations
 tcounts <- as.data.frame(t(normCounts))
-# Assign group labels based on `sampleTable`
-tcounts$group <- sampleTable$condition[match(rownames(tcounts), rownames(sampleTable))]
+# Assign group labels based on colData(dds)
+tcounts$group <- colData(dds)$condition[match(rownames(tcounts), rownames(colData(dds)))]
 # Aggregate group means and standard deviations
 agg_means <- aggregate(. ~ group, data = tcounts, FUN = mean, na.rm = TRUE)
 agg_stdev <- aggregate(. ~ group, data = tcounts, FUN = sd, na.rm = TRUE)


### PR DESCRIPTION
- Do not collapse samples in situations where min # of tech reps = 1
- Update sampleTable accordingly after technical replicates collapse
- Fix group statistics calculation by using colData(dds) directly instead of the sampleTable